### PR TITLE
fix(auth): Restore deleted Zope root Basic auth

### DIFF
--- a/Products/EEAPloneAdmin/profiles/default/metadata.xml
+++ b/Products/EEAPloneAdmin/profiles/default/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <description>EEAPloneAdmin profile</description>
-    <version>20.1</version>
+    <version>20.2</version>
     <dependencies>
         <dependency>profile-valentine.linguaflow:default</dependency>
     </dependencies>

--- a/Products/EEAPloneAdmin/upgrades/configure.zcml
+++ b/Products/EEAPloneAdmin/upgrades/configure.zcml
@@ -4,6 +4,19 @@
     i18n_domain="eea">
 
   <genericsetup:upgradeSteps
+    source="20.1"
+    destination="20.2"
+    profile="Products.EEAPloneAdmin:default">
+
+    <genericsetup:upgradeStep
+        title="Restore deleted Zope root Basic authentication"
+        handler=".setupauthplugins.setup_auth_plugins"
+        />
+    />
+
+  </genericsetup:upgradeSteps>
+
+  <genericsetup:upgradeSteps
     source="19.3"
     destination="20.1"
     profile="Products.EEAPloneAdmin:default">

--- a/Products/EEAPloneAdmin/upgrades/setupauthplugins.py
+++ b/Products/EEAPloneAdmin/upgrades/setupauthplugins.py
@@ -1,0 +1,32 @@
+"""
+Restore deleted Zope root Basic authentication.
+"""
+
+from Products.CMFCore.utils import getToolByName
+
+from Products.PlonePAS import setuphandlers
+
+
+def setup_auth_plugins(self):
+    """
+    Restore deleted Zope root Basic authentication.
+    """
+    # Copied from the code that is run when adding a plone site to a fresh ZODB:
+    # `./plone/app/upgrade/v30/profiles/beta1_beta2/import_steps.xml:32:
+    # handler="Products.PlonePAS.setuphandlers.setupPlonePAS"`
+
+    # Acquire parent user folder.
+    parent = self.getPhysicalRoot()
+
+    # Get the new uf
+    uf = getToolByName(parent, 'acl_users')
+
+    pas = uf.manage_addProduct['PluggableAuthService']
+    plone_pas = uf.manage_addProduct['PlonePAS']
+    setuphandlers.setupAuthPlugins(
+        parent,
+        pas,
+        plone_pas,
+        deactivate_basic_reset=False,
+        deactivate_cookie_challenge=True,
+    )


### PR DESCRIPTION
I tracked down the code that converts the root `acl_users` from a fresh/vanilla Zope2/ZODB
instance to `PluggableAuthService` when a Plone site is added and added an upgrade step
to run the parts of that procedure necessary to get HTTP `Basic` authentication working
again locally.

Refs: #131248

----

This is my first contribution that will actually be run, so be careful with this.  Give
me all the feedback you can think of and test as thoroughly as possible.  This fixed the
issue for me locally, but I haven't tested on my developer Rancher stack, so LMK if you
want me to do that first.